### PR TITLE
Implement ttl cache

### DIFF
--- a/cache/__init__.py
+++ b/cache/__init__.py
@@ -1,1 +1,2 @@
 from .async_lru import AsyncLRU
+from .async_ttl import AsyncTTL

--- a/cache/async_ttl.py
+++ b/cache/async_ttl.py
@@ -1,0 +1,83 @@
+from typing import Any
+from collections import OrderedDict
+import datetime
+
+
+class AsyncTTL:
+    class _TTL(OrderedDict):
+        def __init__(self, time_to_live, min_cleanup_interval, *args, **kwargs):
+            super().__init__(*args, **kwargs)
+            self.time_to_live = datetime.timedelta(seconds=time_to_live)
+            self.min_cleanup_interval = datetime.timedelta(seconds=min_cleanup_interval)
+            self.last_expiration_cleanup_datetime = datetime.datetime.now()
+
+        def __contains__(self, key):
+            if key not in self.keys():
+                return False
+            else:
+                key_expiration = super().__getitem__(key)
+                if key_expiration < datetime.datetime.now():
+                    del self[key]
+                    return False
+                else:
+                    return True
+
+        def __getitem__(self, key):
+            value = super().__getitem__(key)
+            return value
+
+        def __setitem__(self, key, value):
+            ttl_value = datetime.datetime.now() + self.time_to_live
+            super().__setitem__(key, ttl_value)
+
+        def cleanup_expired_keys(self):
+            current_datetime = datetime.datetime.now()
+
+            if current_datetime - self.last_expiration_cleanup_datetime < self.min_cleanup_interval:
+                return
+
+            self.last_expiration_cleanup_datetime = current_datetime
+            for key in list(self.keys()):
+                if self[key] < current_datetime:
+                    del self[key]
+                else:
+                    break
+
+    class _Key:
+        def __init__(self, *args, **kwargs):
+            self.args = args
+            self.kwargs = kwargs
+
+        def __eq__(self, obj):
+            return hash(self) == hash(obj)
+
+        def __hash__(self):
+            def _hash(param: Any):
+                if isinstance(param, tuple):
+                    return tuple(map(_hash, param))
+                if isinstance(param, dict):
+                    return tuple(map(_hash, param.items()))
+                elif hasattr(param, '__dict__'):
+                    return str(vars(param))
+                else:
+                    return str(param)
+
+            return hash(_hash(self.args) + _hash(self.kwargs))
+
+    def __init__(self, time_to_live=1, min_cleanup_interval=5):
+        self.ttl = self._TTL(time_to_live=time_to_live, min_cleanup_interval=min_cleanup_interval)
+
+    def __call__(self, func):
+        async def wrapper(*args, **kwargs):
+            key = self._Key(args, kwargs)
+            if key in self.ttl:
+                val = self.ttl[key]
+            else:
+                self.ttl[key] = await func(*args, **kwargs)
+                val = self.ttl[key]
+            self.ttl.cleanup_expired_keys()
+            return val
+
+        wrapper.__name__ += func.__name__
+
+        return wrapper

--- a/tests/ttl_test.py
+++ b/tests/ttl_test.py
@@ -1,0 +1,86 @@
+from cache import AsyncTTL
+import asyncio
+import time
+
+
+@AsyncTTL(time_to_live=60, min_cleanup_interval=60)
+async def long_expiration_fn(wait: int):
+    await asyncio.sleep(wait)
+
+
+@AsyncTTL(time_to_live=5, min_cleanup_interval=60)
+async def short_expiration_fn(wait: int):
+    await asyncio.sleep(wait)
+
+
+@AsyncTTL(time_to_live=3, min_cleanup_interval=5)
+async def short_cleanup_fn(wait: int):
+    await asyncio.sleep(wait)
+
+
+def cache_hit_test():
+    t1 = time.time()
+    asyncio.get_event_loop().run_until_complete(long_expiration_fn(4))
+    t2 = time.time()
+    asyncio.get_event_loop().run_until_complete(long_expiration_fn(4))
+    t3 = time.time()
+    t_first_exec = (t2 - t1) * 1000
+    t_second_exec = (t3 - t2) * 1000
+    print(t_first_exec)
+    print(t_second_exec)
+    assert t_first_exec > 4000
+    assert t_second_exec < 4000
+
+
+def cache_expiration_test():
+    t1 = time.time()
+    asyncio.get_event_loop().run_until_complete(short_expiration_fn(1))
+    t2 = time.time()
+    asyncio.get_event_loop().run_until_complete(short_expiration_fn(1))
+    t3 = time.time()
+    time.sleep(5)
+    t4 = time.time()
+    asyncio.get_event_loop().run_until_complete(short_expiration_fn(1))
+    t5 = time.time()
+    t_first_exec = (t2 - t1) * 1000
+    t_second_exec = (t3 - t2) * 1000
+    t_third_exec = (t5 - t4) * 1000
+    print(t_first_exec)
+    print(t_second_exec)
+    print(t_third_exec)
+    assert t_first_exec > 1000
+    assert t_second_exec < 1000
+    assert t_third_exec > 1000
+
+
+def cache_cleanup_test():
+    """
+    Requires manual inspection into cache size after each call
+    :return:
+    """
+    t1 = time.time()
+    asyncio.get_event_loop().run_until_complete(short_cleanup_fn(1))
+    t2 = time.time()
+    asyncio.get_event_loop().run_until_complete(short_cleanup_fn(2))
+    t3 = time.time()
+    time.sleep(5)
+    t4 = time.time()
+    asyncio.get_event_loop().run_until_complete(short_cleanup_fn(3))
+    t5 = time.time()
+    t_first_exec = (t2 - t1) * 1000
+    t_second_exec = (t3 - t2) * 1000
+    t_third_exec = (t5 - t4) * 1000
+    print(t_first_exec)
+    print(t_second_exec)
+    print(t_third_exec)
+    assert t_first_exec > 1000
+    assert t_second_exec > 2000
+    assert t_third_exec > 3000
+
+
+if __name__ == "__main__":
+    cache_hit_test()
+    cache_expiration_test()
+
+    # Disabled test to verify auto cache cleanup for expired keys as it requires manual inspection
+    # cache_cleanup_test()


### PR DESCRIPTION
#4  Implemented a separate cache wrapper for TTL.

## How it works
A datetime object is stored as the value for each call. Upon calling an existing key, the underlying cache will attempt to invalidate the key if it has expired. After the end of each call, the cache attempts to invalidate expired keys in the cache by a parameterized interval in seconds.

## How to use
There are 2 parameters to change, 
- one for setting TTL in seconds
- one for setting cache invalidation interval in seconds

## Testing
Added tests for cache hit, cache miss by calling expired key, and a disabled cache auto-invalidation test. The auto-invalidation test has been disabled as internal cache inspection is not exposed as a function.