### PR TITLE
Datetime and types

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -44,11 +44,12 @@ Basic Usage
     
     # TTL Cache
     from cache import AsyncTTL
+    import datetime
     
-    @AsyncTTL(time_to_live=60, maxsize=1024)
+    @AsyncTTL(ttl=datetime.timedelta(seconds=60), maxsize=1024)
     async def func(*args, **kwargs):
         """
-        time_to_live : max time for which a cached result  is valid
+        ttl : max time for which a cached result  is valid
         maxsize : max number of results that are cached.
                   if  max limit  is reached the oldest result  is deleted.
         """

--- a/cache/async_lru.py
+++ b/cache/async_lru.py
@@ -3,10 +3,9 @@ from .lru import LRU
 
 
 class AsyncLRU:
-
-    def __init__(self, maxsize=128):
+    def __init__(self, maxsize: int = 128):
         """
-        :param maxsize: Use maxsize as None for unlimited size cache
+        :param maxsize: Maximal cache size. Use None to not limit cache size.
         """
         self.lru = LRU(maxsize=maxsize)
 

--- a/cache/lru.py
+++ b/cache/lru.py
@@ -1,8 +1,9 @@
 from collections import OrderedDict
+from typing import Union
 
 
 class LRU(OrderedDict):
-    def __init__(self, maxsize, *args, **kwargs):
+    def __init__(self, maxsize: Union[None, int], *args, **kwargs):
         self.maxsize = maxsize
         super().__init__(*args, **kwargs)
 

--- a/tests/lru_test.py
+++ b/tests/lru_test.py
@@ -1,6 +1,7 @@
-from cache import AsyncLRU, AsyncTTL
 import asyncio
 import time
+
+from cache import AsyncLRU, AsyncTTL
 
 
 @AsyncLRU(maxsize=128)
@@ -14,7 +15,7 @@ class TestClassFunc:
         await asyncio.sleep(wait)
 
     @staticmethod
-    @AsyncTTL(maxsize=128, time_to_live=None, skip_args=1)
+    @AsyncTTL(maxsize=128, ttl=None, skip_args=1)
     async def skip_arg_func(arg: int, wait: int):
         await asyncio.sleep(wait)
 

--- a/tests/ttl_test.py
+++ b/tests/ttl_test.py
@@ -1,21 +1,23 @@
-from cache import AsyncTTL
 import asyncio
+import datetime
 import time
 
+from cache import AsyncTTL
 
-@AsyncTTL(time_to_live=60)
+
+@AsyncTTL(ttl=datetime.timedelta(seconds=60))
 async def long_expiration_fn(wait: int):
     await asyncio.sleep(wait)
     return wait
 
 
-@AsyncTTL(time_to_live=5)
+@AsyncTTL(ttl=datetime.timedelta(seconds=5))
 async def short_expiration_fn(wait: int):
     await asyncio.sleep(wait)
     return wait
 
 
-@AsyncTTL(time_to_live=3)
+@AsyncTTL(ttl=datetime.timedelta(seconds=3))
 async def short_cleanup_fn(wait: int):
     await asyncio.sleep(wait)
     return wait
@@ -59,4 +61,3 @@ def cache_expiration_test():
 if __name__ == "__main__":
     cache_hit_test()
     cache_expiration_test()
-


### PR DESCRIPTION
Handing over a `datetime.timedelta` object solves issue  #11 and it is similar to the behaviour of [cachetools' TTLCache](https://cachetools.readthedocs.io/en/stable/#cachetools.TTLCache). That is why I changed `time_to_live` to `ttl`. The tests are still passing, README.rst is updated and I also added some parameter types. Hope you like it, enjoy :).