### PR TITLE
use_cache bugfix

### DIFF
--- a/cache/key.py
+++ b/cache/key.py
@@ -5,6 +5,7 @@ class KEY:
     def __init__(self, *args, **kwargs):
         self.args = args
         self.kwargs = kwargs
+        kwargs.pop("use_cache", None)
 
     def __eq__(self, obj):
         return hash(self) == hash(obj)


### PR DESCRIPTION
Current implementation of use_cache only works once.  Delete the field from the KEY hash to solve this.