### PR TITLE
Improve documentation for skip_args

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -51,8 +51,14 @@ Basic Usage
         time_to_live : max time for which a cached result  is valid
         maxsize : max number of results that are cached.
                   if  max limit  is reached the oldest result  is deleted.
+        skip_args : Use `1` to skip first arg of func in determining cache key
         """
         pass
+
+    class Object:
+        @AsyncTTL(time_to_live=60, maxsize=1024, skip_args=1)
+        async def func(*args, **kwargs):
+            pass
 
     # Supports primitive as well as non-primitive function parameter.
     # Currently TTL & LRU cache is supported.


### PR DESCRIPTION
I ran into a bug in my application because I was including self in the KEY. Completely my fault and `skip_args` is the perfect solution. I thought adding some extra docco might help others to avoid the problem.