### PR TITLE
Fix KEY hashing regression for list args in 2.0.0

### DIFF
--- a/cache/key.py
+++ b/cache/key.py
@@ -4,6 +4,8 @@ from typing import Any
 def _to_hashable(param: Any):
     """Recursive to hashable for stable keys (tuples/dicts/objs).
     - Tuples recursive.
+    - Lists: tuple(recursive).
+    - Sets/frozensets: sorted tuple(recursive).
     - Dicts: sorted items tuple.
     - Objs: str(sorted vars) (deterministic).
     - Else: str (fallback).
@@ -11,6 +13,10 @@ def _to_hashable(param: Any):
     """
     if isinstance(param, tuple):
         return tuple(map(_to_hashable, param))
+    if isinstance(param, list):
+        return tuple(map(_to_hashable, param))
+    if isinstance(param, (set, frozenset)):
+        return tuple(sorted(_to_hashable(item) for item in param))
     if isinstance(param, dict):
         return tuple(sorted((k, _to_hashable(v)) for k, v in param.items()))
     elif hasattr(param, "__dict__"):
@@ -32,7 +38,7 @@ class KEY:
 
     def __init__(self, args, kwargs):
         # args: tuple; kwargs cleaned/sorted for stability
-        self.args = args  # tuple for hash/eq
+        self.args = _to_hashable(args)
         # copy + remove use_cache (decorator param) + sort for stability
         kw = dict(kwargs)  # copy to avoid side-effect on caller
         kw.pop("use_cache", None)
@@ -57,6 +63,8 @@ class KEY:
 def _to_hashable(param: Any):
     """Recursive to hashable for stable keys (tuples/dicts/objs).
     - Tuples recursive.
+    - Lists: tuple(recursive).
+    - Sets/frozensets: sorted tuple(recursive).
     - Dicts: sorted items tuple.
     - Objs: str(vars) (deterministic repr).
     - Else: str (fallback).
@@ -64,6 +72,10 @@ def _to_hashable(param: Any):
     """
     if isinstance(param, tuple):
         return tuple(map(_to_hashable, param))
+    if isinstance(param, list):
+        return tuple(map(_to_hashable, param))
+    if isinstance(param, (set, frozenset)):
+        return tuple(sorted(_to_hashable(item) for item in param))
     if isinstance(param, dict):
         return tuple(sorted((k, _to_hashable(v)) for k, v in param.items()))
     elif hasattr(param, "__dict__"):

--- a/tests/test_cache_features.py
+++ b/tests/test_cache_features.py
@@ -122,6 +122,20 @@ class TestCacheFeatures(unittest.TestCase):
         # used in cache (e.g. herd/batch keys stable)
         # (implicit via other tests)
 
+    def test_key_with_list_args_is_hashable(self):
+        """Regression: list in args should not raise TypeError in KEY hash."""
+        from cache.key import KEY, make_key
+
+        k = KEY((['https://amzn.to/4rPPcFB'],), {})
+        h = hash(k)
+        self.assertIsInstance(h, int)
+
+        async def dummy(links, use_cache=True):
+            return links
+
+        mk = make_key(dummy, (['https://amzn.to/4rPPcFB'],), {'use_cache': True}, skip_args=0)
+        self.assertIsNotNone(mk)
+
     def test_lru_concurrent_eviction(self):
         """Test for concurrency bug in LRU re-runs with unique keys near maxsize.
         Pre-fix (race in move_to_end/evict): hits dropped weirdly (e.g., 3% for size=94 vs ~90% for 95).


### PR DESCRIPTION
Fix `KEY` hashing regression for list args in 2.0.0

## Summary

This PR fixes a regression where decorator keys crash with:

`TypeError: unhashable type: 'list'`

when cached functions receive list arguments.

## Root cause

`KEY.__hash__` in `cache/key.py` hashes `self.args` directly, but `self.args` currently stores raw args. If args contain list values, hash fails.

## Changes

- Normalize `args` in `KEY.__init__` using `_to_hashable`.
- Extend `_to_hashable` to explicitly support:
  - `list` -> tuple(recursive)
  - `set`/`frozenset` -> sorted tuple(recursive)
- Add regression test in `tests/test_cache_features.py` to ensure list args are hashable via both `KEY` and `make_key`.

## Backward compatibility

No API changes. Only key canonicalization/hashing is hardened.

## Validation

- New regression test covers the failing case.
- Existing key stability behavior remains intact.
