### PR TITLE
fix: ensure that future exception is retrieved to avoid warnings

### DIFF
--- a/cache/async_cache.py
+++ b/cache/async_cache.py
@@ -89,6 +89,7 @@ class AsyncCache:
                 return value
             except Exception as exc:
                 fut.set_exception(exc)
+                fut.exception()
                 raise
             finally:
                 # cleanup under lock

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -12,6 +12,7 @@ Tests for backward compatibility, robustness, and all features including:
 """
 
 import asyncio
+import gc
 import random
 import time
 import unittest
@@ -572,6 +573,42 @@ class TestErrorHandling(unittest.TestCase):
             result = await cache.get('key', loader=success_loader)
             self.assertEqual(result, 'success')
         
+        asyncio.run(_test())
+
+    def test_future_exception_retrival(self):
+        """Ensure Future exceptions are retrieved to avoid warnings."""
+        async def _test():
+            cache = AsyncCache()
+            loop = asyncio.get_running_loop()
+            original_handler = loop.get_exception_handler()
+            warning_messages = []
+
+            def exception_handler(_loop, context):
+                message = context.get("message", "")
+                if "Future exception was never retrieved" in message:
+                    warning_messages.append(message)
+                if original_handler is not None:
+                    original_handler(_loop, context)
+
+            loop.set_exception_handler(exception_handler)
+
+            async def failing_loader():
+                raise ValueError("Load failed")
+
+            # Trigger loader failure
+            try:
+                with self.assertRaises(ValueError):
+                    await cache.get('key', loader=failing_loader)
+
+                # Ensure Future finalizers run before assertions.
+                gc.collect()
+                await asyncio.sleep(0)
+            finally:
+                loop.set_exception_handler(original_handler)
+
+            # Check that no "Future exception was never retrieved" warning occurs
+            self.assertEqual(warning_messages, [])
+
         asyncio.run(_test())
 
 


### PR DESCRIPTION
### Problem description

When a decorated coroutine raises, the caller may correctly catch that exception, but the cache internals can still leave an unresolved/rejected internal Future state that triggers event-loop warnings such as "Future exception was never retrieved" during shutdown/GC.

So the user-visible error is handled, yet noisy background warnings still appear and are reported to APM tools (e.g. sentry).

In short, the problem is:

- a cached async call fails,
- the exception is propagated to user code,
- but cache internals may still emit unhandled-future warnings afterward.

Code snippet demonstrating the issue:
```
import asyncio
from cache import AsyncTTL


@AsyncTTL()
async def test():
    raise Exception()


if __name__ == "__main__":
    try:
        asyncio.run(test())
    except Exception:
        pass
```
The same code without the decorator `AsyncTTL` produces no warning on exit/GC.

The fix marks the exception as retrieved on the Future object, so that it does not produce warning when a Future is garbage collected. Waiters still receive the exception correctly, and the leader still re-raises it normally.